### PR TITLE
Set working directory for UniFi controller

### DIFF
--- a/templates/unifi.service.j2
+++ b/templates/unifi.service.j2
@@ -4,6 +4,7 @@ After=syslog.target network.target
 
 [Service]
 Type=simple
+WorkingDirectory={{ unifi_install_destination }}
 ExecStart=/usr/bin/java -jar {{ unifi_install_destination }}/UniFi/lib/ace.jar start &
 ExecStop=/usr/bin/java -jar {{ unifi_install_destination }}/UniFi/lib/ace.jar stop &
 User={{ unifi_user }}


### PR DESCRIPTION
Pär - Thanks for the role!

I found on my system that I had to set the working directory in the service file, or the controller wouldn't correctly locate resources in the installation directory (e.g. logfile paths). A pull request to set the working directory is attached.